### PR TITLE
Storyboard image pipeline: narrative-first prompts, Step2 merge, t2i guard

### DIFF
--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -242,6 +242,8 @@ type Repository interface {
 	CreateSceneGeneration(ctx context.Context, gen *StoryboardSceneGeneration) error
 	GetSceneGeneration(ctx context.Context, id string) (*StoryboardSceneGeneration, error)
 	ListSceneGenerations(ctx context.Context, storyboardID string) ([]*StoryboardSceneGeneration, error)
+	// LatestCompletedSceneGenerationByScene returns the most recent completed Step-2 row for a storyboard scene (plot scene id).
+	LatestCompletedSceneGenerationByScene(ctx context.Context, storyboardID, sceneID string) (*StoryboardSceneGeneration, error)
 	UpdateSceneGeneration(ctx context.Context, gen *StoryboardSceneGeneration) error
 
 	// Image generation (Step 3)

--- a/internal/repository/mysql/storyboard_generation_impl.go
+++ b/internal/repository/mysql/storyboard_generation_impl.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/grapestree/fgrapery/grapery/internal/domain"
 	"gorm.io/gorm"
@@ -70,6 +71,25 @@ func (r *Repository) ListSceneGenerations(ctx context.Context, storyboardID stri
 		result[i] = ModelToStoryboardSceneGeneration(&m)
 	}
 	return result, nil
+}
+
+func (r *Repository) LatestCompletedSceneGenerationByScene(ctx context.Context, storyboardID, sceneID string) (*domain.StoryboardSceneGeneration, error) {
+	var model StoryboardSceneGeneration
+	err := r.db.WithContext(ctx).
+		Where("storyboard_id = ? AND scene_id = ? AND status = ?", storyboardID, sceneID, domain.GenerationStatusCompleted).
+		Order("created_at DESC, id DESC").
+		First(&model).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	d := ModelToStoryboardSceneGeneration(&model)
+	if strings.TrimSpace(d.GeneratedDetail) == "" {
+		return nil, domain.ErrNotFound
+	}
+	return d, nil
 }
 
 func (r *Repository) UpdateSceneGeneration(ctx context.Context, gen *domain.StoryboardSceneGeneration) error {

--- a/internal/service/storyboard.go
+++ b/internal/service/storyboard.go
@@ -2647,12 +2647,34 @@ func (s *Service) generateSceneImages(ctx context.Context, storyboard *domain.St
 		if i > 0 {
 			prev = &storyboard.StoryboardScenes[i-1]
 		}
+
+		mergedDesc := strings.TrimSpace(scene.Description)
+		if s.repo != nil && strings.TrimSpace(storyboard.ID) != "" && strings.TrimSpace(scene.ID) != "" {
+			if detailGen, err := s.repo.LatestCompletedSceneGenerationByScene(ctx, storyboard.ID, scene.ID); err == nil && detailGen != nil {
+				mergedDesc = mergeStoryboardSceneDescriptionForImage(scene.Description, detailGen.GeneratedDetail)
+				mergedDesc = strings.TrimSpace(mergedDesc)
+			}
+		}
+		sceneForPrompt := *scene
+		sceneForPrompt.Description = mergedDesc
+
 		// 构建图片提示词（包含故事风格配置）
-		prompt := s.buildStoryboardSceneImagePromptWithStyle(scene, storyStyle, isTransitionScene, prev)
+		prompt := s.buildStoryboardSceneImagePromptWithStyle(&sceneForPrompt, storyStyle, isTransitionScene, prev)
+		refForAPI := referenceImages
+		narrativeRunes := utf8.RuneCountInString(mergedDesc)
+		if !isTransitionScene && narrativeRunes >= storyboardImageT2INarrativeMinRunes {
+			refForAPI = nil
+		}
+		if len(refForAPI) > 0 {
+			prompt = appendStoryboardImageToImageConstraints(prompt, true)
+		}
+		prompt = truncateStringToMaxRunes(strings.TrimSpace(prompt), storyboardImageFinalMaxRunes)
 		s.logger.Debug("scene image prompt built",
 			zap.String("storyboardId", storyboard.ID),
 			zap.Int("sceneIndex", i),
-			zap.Int("promptLength", len(prompt)))
+			zap.Int("promptLength", len(prompt)),
+			zap.Int("narrativeRunes", narrativeRunes),
+			zap.Int("referenceCountForAPI", len(refForAPI)))
 
 		// 使用AI生成服务生成图片（自动记录AI使用数据）
 		imageReq := &GenerateImageRequest{
@@ -2663,7 +2685,7 @@ func (s *Service) generateSceneImages(ctx context.Context, storyboard *domain.St
 			AspectRatio:       "16:9",
 			Quality:           "high",
 			OutputCount:       1,
-			ReferenceImages:   referenceImages, // 使用角色参考图片
+			ReferenceImages:   refForAPI,
 			RelatedEntityID:   storyboard.ID,
 			RelatedEntityType: "storyboard_scene",
 			Metadata: map[string]interface{}{

--- a/internal/service/storyboard_comic_page.go
+++ b/internal/service/storyboard_comic_page.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/grapestree/fgrapery/grapery/internal/aliyun"
@@ -95,6 +96,8 @@ func (s *Service) GenerateStoryboardComicPage(ctx context.Context, req *ComicPag
 		characterRefImages = s.getCharacterImagesForScene(ctx, storyboard.StoryID, req.SceneCharacters)
 	}
 
+	mergedSceneDescription := s.MergedStoryboardSceneDescriptionForImage(ctx, req.StoryboardID, req.SceneID, req.SceneDescription)
+
 	isTransitionScene := len(req.SceneCharacters) == 0 && len(characterRefImages) == 0
 
 	panelURL := strings.TrimSpace(s.previousStoryboardScenePanelImageURL(ctx, req.StoryboardID, req.SceneID))
@@ -133,7 +136,7 @@ func (s *Service) GenerateStoryboardComicPage(ctx context.Context, req *ComicPag
 		StoryboardID:             req.StoryboardID,
 		SceneID:                  req.SceneID,
 		SceneTitle:               req.SceneTitle,
-		SceneDescription:         req.SceneDescription,
+		SceneDescription:         mergedSceneDescription,
 		ReferenceImages:          allReferenceImages,
 		SceneCharacters:          req.SceneCharacters,
 		CharacterReferenceImages: characterRefImages,
@@ -206,12 +209,13 @@ func (s *Service) processComicPageGeneration(ctx context.Context, gen *domain.St
 			return
 		}
 
-		promptDetails, combinedPrompt := s.parseImagePromptDetails(text)
+		promptDetails, combinedPrompt := s.parseImagePromptDetails(text, gen.SceneTitle, gen.SceneDescription)
 		if promptDetails != nil {
 			gen.PromptDetails = promptDetails
 			gen.GeneratedPrompt = combinedPrompt
 		} else {
-			gen.GeneratedPrompt = text
+			nb := storyboardSceneNarrativeBlock(gen.SceneTitle, gen.SceneDescription)
+			gen.GeneratedPrompt = prependStoryboardImageNarrativeBlock(nb, capGeminiImageBeautyOutput(strings.TrimSpace(text)))
 		}
 		if resp != nil && resp.UsageMetadata != nil {
 			gen.InputTokens = int(resp.UsageMetadata.PromptTokenCount)
@@ -220,11 +224,16 @@ func (s *Service) processComicPageGeneration(ctx context.Context, gen *domain.St
 		}
 		s.recordStoryboardTextGeneration(ctx, gen.StoryboardID, "comic_page_image_prompt", promptGen, gen.InputTokens, gen.OutputTokens, domain.AITaskStatusCompleted, "")
 	} else {
-		gen.GeneratedPrompt = gen.SceneDescription
+		nb := storyboardSceneNarrativeBlock(gen.SceneTitle, gen.SceneDescription)
+		if nb != "" {
+			gen.GeneratedPrompt = nb
+		} else {
+			gen.GeneratedPrompt = strings.TrimSpace(gen.SceneDescription)
+		}
 	}
 
 	if gen.GeneratedPrompt != "" {
-		gen.GeneratedPrompt = truncateStringToMaxRunes(strings.TrimSpace(gen.GeneratedPrompt), maxStoryboardAIGeneratedPromptRunes)
+		gen.GeneratedPrompt = finalizeStoryboardImagePromptForAPI(gen)
 	}
 
 	aspect := strings.TrimSpace(opts.PageAspectRatio)
@@ -232,21 +241,22 @@ func (s *Service) processComicPageGeneration(ctx context.Context, gen *domain.St
 		aspect = "9:16"
 	}
 
-	if s.genAPI != nil && gen.GeneratedPrompt != "" {
+	narrativeRunes := utf8.RuneCountInString(strings.TrimSpace(gen.SceneDescription))
+	refURLs, imgOp, refPrimary := selectStoryboardImageRefsAndOperation(gen, narrativeRunes)
+	useRefs := len(refURLs) > 0 && imgOp == genapi.OperationImageToImage
+	finalPrompt := appendStoryboardImageToImageConstraints(strings.TrimSpace(gen.GeneratedPrompt), useRefs)
+
+	if s.genAPI != nil && finalPrompt != "" {
 		genReq := &genapi.GenerateRequest{
-			Prompt:          gen.GeneratedPrompt,
+			Prompt:          finalPrompt,
 			AspectRatio:     aspect,
 			Quality:         "high",
 			OutputCount:     1,
-			ReferenceImages: gen.ReferenceImages,
+			ReferenceImages: refURLs,
 			Metadata:        s.usageRecordMetadataForStoryboard(ctx, gen.StoryboardID),
 		}
-		if len(gen.ReferenceImages) > 0 {
-			genReq.Operation = genapi.OperationImageToImage
-			genReq.ReferenceImageURL = gen.ReferenceImages[0]
-		} else {
-			genReq.Operation = genapi.OperationTextToImage
-		}
+		genReq.Operation = imgOp
+		genReq.ReferenceImageURL = refPrimary
 		imageProvider := s.imageProvider
 		if imageProvider == "" {
 			imageProvider = "huoshan"

--- a/internal/service/storyboard_generation.go
+++ b/internal/service/storyboard_generation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/grapestree/fgrapery/grapery/internal/aliyun"
@@ -633,6 +634,8 @@ func (s *Service) GenerateSceneImage(ctx context.Context, req *ImageGenerationRe
 		zap.String("storyboardId", req.StoryboardID),
 		zap.String("storyId", storyboard.StoryID))
 
+	mergedSceneDescription := s.MergedStoryboardSceneDescriptionForImage(ctx, req.StoryboardID, req.SceneID, req.SceneDescription)
+
 	// 获取故事信息和风格配置
 	var storyStyle *domain.StyleConfig
 	if req.StoryStyle != nil {
@@ -703,7 +706,7 @@ func (s *Service) GenerateSceneImage(ctx context.Context, req *ImageGenerationRe
 		StoryboardID:             req.StoryboardID,
 		SceneID:                  req.SceneID,
 		SceneTitle:               req.SceneTitle,
-		SceneDescription:         req.SceneDescription,
+		SceneDescription:         mergedSceneDescription,
 		ReferenceImages:          allReferenceImages,
 		SceneCharacters:          req.SceneCharacters,
 		CharacterReferenceImages: characterRefImages,
@@ -1005,7 +1008,7 @@ func (s *Service) processImageGeneration(ctx context.Context, gen *domain.Storyb
 		}
 
 		// Parse structured prompt details from AI response
-		promptDetails, combinedPrompt := s.parseImagePromptDetails(text)
+		promptDetails, combinedPrompt := s.parseImagePromptDetails(text, gen.SceneTitle, gen.SceneDescription)
 		if promptDetails != nil {
 			gen.PromptDetails = promptDetails
 			gen.GeneratedPrompt = combinedPrompt
@@ -1018,8 +1021,9 @@ func (s *Service) processImageGeneration(ctx context.Context, gen *domain.Storyb
 				s.metrics.RecordImageGenerationPromptDetails(true)
 			}
 		} else {
-			// Fallback: use raw text as prompt if parsing fails
-			gen.GeneratedPrompt = text
+			// Fallback: use raw text as prompt if parsing fails (still anchor with narrative block)
+			nb := storyboardSceneNarrativeBlock(gen.SceneTitle, gen.SceneDescription)
+			gen.GeneratedPrompt = prependStoryboardImageNarrativeBlock(nb, capGeminiImageBeautyOutput(strings.TrimSpace(text)))
 			s.logger.Warn("failed to parse structured prompt, using raw text",
 				zap.String("generationId", gen.ID),
 				zap.String("rawText", truncateForLog(text, 200)))
@@ -1058,39 +1062,48 @@ func (s *Service) processImageGeneration(ctx context.Context, gen *domain.Storyb
 		s.logger.Warn("no AI client available, using scene description as prompt",
 			zap.String("generationId", gen.ID),
 			zap.String("sceneId", gen.SceneID))
-		gen.GeneratedPrompt = gen.SceneDescription
+		nb := storyboardSceneNarrativeBlock(gen.SceneTitle, gen.SceneDescription)
+		if nb != "" {
+			gen.GeneratedPrompt = nb
+		} else {
+			gen.GeneratedPrompt = strings.TrimSpace(gen.SceneDescription)
+		}
 	}
 
 	if gen.GeneratedPrompt != "" {
-		gen.GeneratedPrompt = truncateStringToMaxRunes(strings.TrimSpace(gen.GeneratedPrompt), maxStoryboardAIGeneratedPromptRunes)
+		gen.GeneratedPrompt = finalizeStoryboardImagePromptForAPI(gen)
 	}
+
+	narrativeRunes := utf8.RuneCountInString(strings.TrimSpace(gen.SceneDescription))
+	refURLs, imgOp, refPrimary := selectStoryboardImageRefsAndOperation(gen, narrativeRunes)
+	useRefs := len(refURLs) > 0 && imgOp == genapi.OperationImageToImage
+	finalPrompt := appendStoryboardImageToImageConstraints(strings.TrimSpace(gen.GeneratedPrompt), useRefs)
 
 	// Generate actual image using genAPI directly
 	// TokenUsageRecorder 会自动将 token 消耗和成功/失败记录到 AIGenerationRecord
-	if s.genAPI != nil && gen.GeneratedPrompt != "" {
+	if s.genAPI != nil && finalPrompt != "" {
 		genReq := &genapi.GenerateRequest{
-			Prompt:          gen.GeneratedPrompt,
+			Prompt:          finalPrompt,
 			AspectRatio:     "16:9",
 			Quality:         "high",
 			OutputCount:     1,
-			ReferenceImages: gen.ReferenceImages, // Use character reference images
+			ReferenceImages: refURLs,
 			Metadata:        s.usageRecordMetadataForStoryboard(ctx, gen.StoryboardID),
 		}
 
-		// Choose operation type based on whether reference images are provided
-		if len(gen.ReferenceImages) > 0 {
-			genReq.Operation = genapi.OperationImageToImage
-			// Use first reference image as the primary reference
-			genReq.ReferenceImageURL = gen.ReferenceImages[0]
+		genReq.Operation = imgOp
+		genReq.ReferenceImageURL = refPrimary
+		if imgOp == genapi.OperationImageToImage {
 			s.logger.Debug("using image-to-image operation",
 				zap.String("generationId", gen.ID),
 				zap.String("sceneId", gen.SceneID),
-				zap.String("referenceImageURL", genReq.ReferenceImageURL))
+				zap.String("referenceImageURL", genReq.ReferenceImageURL),
+				zap.Int("referenceImageCount", len(refURLs)))
 		} else {
-			genReq.Operation = genapi.OperationTextToImage
 			s.logger.Debug("using text-to-image operation",
 				zap.String("generationId", gen.ID),
-				zap.String("sceneId", gen.SceneID))
+				zap.String("sceneId", gen.SceneID),
+				zap.Int("narrativeRunes", narrativeRunes))
 		}
 
 		// Use configured image provider (default: huoshan)
@@ -1107,7 +1120,7 @@ func (s *Service) processImageGeneration(ctx context.Context, gen *domain.Storyb
 			zap.String("sceneId", gen.SceneID),
 			zap.String("provider", imageProvider),
 			zap.String("operation", string(genReq.Operation)),
-			zap.String("prompt", truncateForLog(gen.GeneratedPrompt, 200)))
+			zap.String("prompt", truncateForLog(finalPrompt, 200)))
 
 		resp, err := s.genAPI.GenerateImage(ctx, imageProvider, genReq)
 		if err != nil {
@@ -3372,13 +3385,13 @@ Please return a structured JSON object (without markdown code blocks) with the f
 }
 
 Important: Return ONLY the JSON object, no explanations or markdown formatting.
-LENGTH: When the field values are merged into one image prompt, keep the total substantive Chinese text (汉字) within 200 characters — be concise; shorten secondary details first if needed.`)
+LENGTH: Keep each JSON string field concise (roughly one short phrase or clause each). The server will prepend the full scene narrative separately; your JSON supplies cinematography and look only.`)
 
 	return prompt.String()
 }
 
 // parseImagePromptDetails 解析AI返回的结构化提示词JSON
-func (s *Service) parseImagePromptDetails(text string) (*domain.ImagePromptDetails, string) {
+func (s *Service) parseImagePromptDetails(text, sceneTitle, sceneDescription string) (*domain.ImagePromptDetails, string) {
 	// Clean the text - remove markdown code blocks if present
 	cleanedText := strings.TrimSpace(text)
 	if strings.HasPrefix(cleanedText, "```") {
@@ -3411,13 +3424,13 @@ func (s *Service) parseImagePromptDetails(text string) (*domain.ImagePromptDetai
 	}
 
 	// Combine structured details into final prompt text
-	combinedPrompt := s.combineImagePrompt(&details)
+	combinedPrompt := s.combineImagePrompt(&details, sceneTitle, sceneDescription)
 
 	return &details, combinedPrompt
 }
 
 // combineImagePrompt 将结构化的提示词详情组合成最终的文本提示词
-func (s *Service) combineImagePrompt(details *domain.ImagePromptDetails) string {
+func (s *Service) combineImagePrompt(details *domain.ImagePromptDetails, sceneTitle, sceneDescription string) string {
 	var parts []string
 
 	if details.ArtStyle != "" {
@@ -3442,7 +3455,10 @@ func (s *Service) combineImagePrompt(details *domain.ImagePromptDetails) string 
 		parts = append(parts, details.AdditionalNotes)
 	}
 
-	return strings.Join(parts, ". ")
+	beauty := strings.Join(parts, ". ")
+	beauty = capGeminiImageBeautyOutput(beauty)
+	nb := storyboardSceneNarrativeBlock(sceneTitle, sceneDescription)
+	return prependStoryboardImageNarrativeBlock(nb, beauty)
 }
 
 // parseVideoPromptDetails 解析AI返回的结构化视频提示词JSON

--- a/internal/service/storyboard_image_prompt.go
+++ b/internal/service/storyboard_image_prompt.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/grapestree/fgrapery/grapery/internal/domain"
+	genapi "github.com/grapestree/fgrapery/grapery/internal/genai"
+)
+
+// Limits for storyboard image pipeline (A/B/C): keep narrative; allow longer final prompts; optional text-to-image when narrative is rich.
+const (
+	storyboardImageT2INarrativeMinRunes = 120
+	storyboardImageFinalMaxRunes        = 4000
+	storyboardImageBeautyMaxRunes       = 600 // cap Gemini "beauty" expansion when preserving narrative block
+)
+
+// MergedStoryboardSceneDescriptionForImage returns plot scene text merged with the latest completed Step-2 detail when available.
+func (s *Service) MergedStoryboardSceneDescriptionForImage(ctx context.Context, storyboardID, sceneID, plotDescription string) string {
+	plotDescription = strings.TrimSpace(plotDescription)
+	if s == nil || s.repo == nil {
+		return plotDescription
+	}
+	storyboardID, sceneID = strings.TrimSpace(storyboardID), strings.TrimSpace(sceneID)
+	if storyboardID == "" || sceneID == "" {
+		return plotDescription
+	}
+	detailGen, err := s.repo.LatestCompletedSceneGenerationByScene(ctx, storyboardID, sceneID)
+	if err != nil || detailGen == nil {
+		return plotDescription
+	}
+	return strings.TrimSpace(mergeStoryboardSceneDescriptionForImage(plotDescription, detailGen.GeneratedDetail))
+}
+
+// mergeStoryboardSceneDescriptionForImage prefers Step-2 cinematic detail when present; otherwise uses the plot description.
+func mergeStoryboardSceneDescriptionForImage(plotDescription, step2Detail string) string {
+	plotDescription = strings.TrimSpace(plotDescription)
+	step2Detail = strings.TrimSpace(step2Detail)
+	if step2Detail == "" {
+		return plotDescription
+	}
+	if plotDescription == "" {
+		return step2Detail
+	}
+	if strings.Contains(plotDescription, step2Detail) {
+		return plotDescription
+	}
+	return plotDescription + "\n\n[Scene detail / cinematography]\n" + step2Detail
+}
+
+func storyboardSceneNarrativeBlock(title, description string) string {
+	title = strings.TrimSpace(title)
+	description = strings.TrimSpace(description)
+	var b strings.Builder
+	b.WriteString("【分镜叙事 / Scene to illustrate — follow faithfully】\n")
+	if title != "" {
+		b.WriteString("Title: ")
+		b.WriteString(title)
+		b.WriteByte('\n')
+	}
+	if description != "" {
+		b.WriteString("Description:\n")
+		b.WriteString(description)
+		b.WriteByte('\n')
+	}
+	out := strings.TrimSpace(b.String())
+	if out == "【分镜叙事 / Scene to illustrate — follow faithfully】" {
+		return ""
+	}
+	return out
+}
+
+func narrativeFingerprint(desc string) string {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return ""
+	}
+	r := []rune(desc)
+	const maxFP = 80
+	if len(r) > maxFP {
+		return string(r[:maxFP])
+	}
+	return desc
+}
+
+func beautyAlreadyEmbedsNarrative(narrativeBlock, beauty string) bool {
+	fp := narrativeFingerprint(narrativeBlock)
+	if fp == "" {
+		return false
+	}
+	return strings.Contains(beauty, fp)
+}
+
+// prependStoryboardImageNarrativeBlock puts the plot narrative before the model-expanded visual prompt.
+func prependStoryboardImageNarrativeBlock(narrativeBlock, beauty string) string {
+	narrativeBlock = strings.TrimSpace(narrativeBlock)
+	beauty = strings.TrimSpace(beauty)
+	if narrativeBlock == "" {
+		return beauty
+	}
+	if beauty == "" {
+		return narrativeBlock
+	}
+	if beautyAlreadyEmbedsNarrative(narrativeBlock, beauty) {
+		return beauty
+	}
+	return narrativeBlock + "\n\n【画面与镜头 / Visual direction】\n" + beauty
+}
+
+func appendStoryboardImageToImageConstraints(prompt string, useReferenceImages bool) string {
+	prompt = strings.TrimSpace(prompt)
+	if !useReferenceImages || prompt == "" {
+		return prompt
+	}
+	const c = "\n\n[Reference images: identity only] Use reference images ONLY to preserve the main cast's face, body type, hair, and costume identity. You MUST still redraw the full scene from the narrative above: correct pose, interaction, props, environment, and shot composition. Do NOT paste or lightly retouch the reference onto a new background; avoid a \"same pose, new backdrop\" result."
+	return prompt + c
+}
+
+// truncateStoryboardImagePromptPreservingNarrative keeps the narrative block intact and trims the tail (visual direction) if needed.
+func truncateStoryboardImagePromptPreservingNarrative(narrativeBlock, full string, maxTotalRunes int) string {
+	full = strings.TrimSpace(full)
+	if maxTotalRunes <= 0 || full == "" {
+		return full
+	}
+	narrativeBlock = strings.TrimSpace(narrativeBlock)
+	if narrativeBlock == "" {
+		return truncateStringToMaxRunes(full, maxTotalRunes)
+	}
+	nr := []rune(narrativeBlock)
+	if len(nr) >= maxTotalRunes {
+		return string(nr[:maxTotalRunes])
+	}
+	sep := "\n\n【画面与镜头 / Visual direction】\n"
+	idx := strings.Index(full, sep)
+	if idx == -1 {
+		return truncateStringToMaxRunes(full, maxTotalRunes)
+	}
+	prefix := full[:idx]
+	beauty := strings.TrimSpace(full[idx+len(sep):])
+	prefixRunes := utf8.RuneCountInString(prefix)
+	if prefixRunes > maxTotalRunes {
+		return truncateStringToMaxRunes(prefix, maxTotalRunes)
+	}
+	remaining := maxTotalRunes - prefixRunes - utf8.RuneCountInString(sep)
+	if remaining <= 0 {
+		return truncateStringToMaxRunes(prefix, maxTotalRunes)
+	}
+	beauty = truncateStringToMaxRunes(beauty, remaining)
+	if beauty == "" {
+		return strings.TrimSpace(prefix)
+	}
+	return strings.TrimSpace(prefix) + sep + beauty
+}
+
+// capGeminiImageBeautyOutput limits only the LLM-expanded portion before narrative merge (Step C: JSON fields stay short; final cap is separate).
+func capGeminiImageBeautyOutput(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	return truncateStringToMaxRunes(s, storyboardImageBeautyMaxRunes)
+}
+
+// finalizeStoryboardImagePromptForAPI trims the full prompt while keeping the narrative block (already prepended by combineImagePrompt / fallbacks).
+func finalizeStoryboardImagePromptForAPI(gen *domain.StoryboardImageGeneration) string {
+	if gen == nil {
+		return ""
+	}
+	nb := storyboardSceneNarrativeBlock(gen.SceneTitle, gen.SceneDescription)
+	full := strings.TrimSpace(gen.GeneratedPrompt)
+	return truncateStoryboardImagePromptPreservingNarrative(nb, full, storyboardImageFinalMaxRunes)
+}
+
+// selectStoryboardImageRefsAndOperation chooses text-to-image when narrative is long enough to avoid "portrait swap background" bias.
+func selectStoryboardImageRefsAndOperation(gen *domain.StoryboardImageGeneration, narrativeRunes int) (refs []string, op genapi.OperationType, primaryURL string) {
+	if gen == nil || len(gen.ReferenceImages) == 0 {
+		return nil, genapi.OperationTextToImage, ""
+	}
+	refs = append([]string(nil), gen.ReferenceImages...)
+	if gen.IsTransitionScene {
+		return refs, genapi.OperationImageToImage, strings.TrimSpace(refs[0])
+	}
+	if narrativeRunes >= storyboardImageT2INarrativeMinRunes {
+		return nil, genapi.OperationTextToImage, ""
+	}
+	return refs, genapi.OperationImageToImage, strings.TrimSpace(refs[0])
+}

--- a/internal/service/storyboard_image_prompt_test.go
+++ b/internal/service/storyboard_image_prompt_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/grapestree/fgrapery/grapery/internal/domain"
+	genapi "github.com/grapestree/fgrapery/grapery/internal/genai"
+)
+
+func TestMergeStoryboardSceneDescriptionForImage(t *testing.T) {
+	got := mergeStoryboardSceneDescriptionForImage("plot", "detail")
+	if !strings.Contains(got, "plot") || !strings.Contains(got, "detail") {
+		t.Fatalf("expected both parts: %q", got)
+	}
+	if mergeStoryboardSceneDescriptionForImage("", "d") != "d" {
+		t.Fatal("empty plot")
+	}
+	if mergeStoryboardSceneDescriptionForImage("p", "") != "p" {
+		t.Fatal("empty detail")
+	}
+}
+
+func TestPrependStoryboardImageNarrativeBlock(t *testing.T) {
+	nb := storyboardSceneNarrativeBlock("T", "Desc line")
+	out := prependStoryboardImageNarrativeBlock(nb, "Art style: x")
+	if !strings.HasPrefix(out, "【分镜叙事") {
+		t.Fatalf("expected narrative prefix: %q", out)
+	}
+	if !strings.Contains(out, "Art style: x") {
+		t.Fatalf("expected beauty tail: %q", out)
+	}
+}
+
+func TestTruncateStoryboardImagePromptPreservingNarrative(t *testing.T) {
+	nb := storyboardSceneNarrativeBlock("T", strings.Repeat("汉", 30))
+	beauty := strings.Repeat("B", 500)
+	full := nb + "\n\n【画面与镜头 / Visual direction】\n" + beauty
+	out := truncateStoryboardImagePromptPreservingNarrative(nb, full, 120)
+	if !strings.HasPrefix(out, "【分镜叙事") {
+		t.Fatalf("narrative should be preserved at start: %q", truncateForTest(out, 80))
+	}
+	if utf8.RuneCountInString(out) > 120 {
+		t.Fatalf("expected max 120 runes, got %d", utf8.RuneCountInString(out))
+	}
+}
+
+func truncateForTest(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "..."
+}
+
+func TestSelectStoryboardImageRefsAndOperation(t *testing.T) {
+	gen := &domain.StoryboardImageGeneration{
+		IsTransitionScene: false,
+		ReferenceImages:   []string{"http://a", "http://b"},
+	}
+	refs, op, _ := selectStoryboardImageRefsAndOperation(gen, storyboardImageT2INarrativeMinRunes)
+	if op != genapi.OperationTextToImage || len(refs) != 0 {
+		t.Fatalf("long narrative should force t2i: op=%s len=%d", op, len(refs))
+	}
+	refs2, op2, primary := selectStoryboardImageRefsAndOperation(gen, 10)
+	if op2 != genapi.OperationImageToImage || len(refs2) != 2 || primary != "http://a" {
+		t.Fatalf("short narrative should keep i2i: op=%s refs=%v primary=%q", op2, refs2, primary)
+	}
+	genTrans := &domain.StoryboardImageGeneration{
+		IsTransitionScene: true,
+		ReferenceImages:   []string{"http://p"},
+	}
+	refs3, op3, _ := selectStoryboardImageRefsAndOperation(genTrans, 500)
+	if op3 != genapi.OperationImageToImage || len(refs3) != 1 {
+		t.Fatalf("transition should keep i2i: op=%s len=%d", op3, len(refs3))
+	}
+}

--- a/internal/transport/http/storyboard_generation.go
+++ b/internal/transport/http/storyboard_generation.go
@@ -217,20 +217,20 @@ func (h *Handler) GenerateAllStoryboardComicPages(c *gin.Context) {
 	}
 
 	var req struct {
-		RegenerateAll     bool   `json:"regenerateAll"`
-		LayoutPreset      string `json:"layoutPreset"`
-		PanelCount        int    `json:"panelCount"`
-		PageAspectRatio   string `json:"pageAspectRatio"`
-		DialogueMode      string `json:"dialogueMode"`
+		RegenerateAll   bool   `json:"regenerateAll"`
+		LayoutPreset    string `json:"layoutPreset"`
+		PanelCount      int    `json:"panelCount"`
+		PageAspectRatio string `json:"pageAspectRatio"`
+		DialogueMode    string `json:"dialogueMode"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		req = struct {
-			RegenerateAll     bool   `json:"regenerateAll"`
-			LayoutPreset      string `json:"layoutPreset"`
-			PanelCount        int    `json:"panelCount"`
-			PageAspectRatio   string `json:"pageAspectRatio"`
-			DialogueMode      string `json:"dialogueMode"`
+			RegenerateAll   bool   `json:"regenerateAll"`
+			LayoutPreset    string `json:"layoutPreset"`
+			PanelCount      int    `json:"panelCount"`
+			PageAspectRatio string `json:"pageAspectRatio"`
+			DialogueMode    string `json:"dialogueMode"`
 		}{}
 	}
 
@@ -290,11 +290,12 @@ func (h *Handler) GenerateAllStoryboardComicPages(c *gin.Context) {
 			}
 		}
 
+		mergedDesc := h.svc.MergedStoryboardSceneDescriptionForImage(c.Request.Context(), storyboardID, scene.ID, scene.Description)
 		genReq := &service.ComicPageGenerationRequest{
 			StoryboardID:             storyboardID,
 			SceneID:                  scene.ID,
 			SceneTitle:               scene.Title,
-			SceneDescription:         scene.Description,
+			SceneDescription:         mergedDesc,
 			ReferenceImages:          referenceImages,
 			SceneCharacters:          scene.Characters,
 			CharacterReferenceImages: referenceImages,
@@ -421,11 +422,12 @@ func (h *Handler) GenerateAllStoryboardImages(c *gin.Context) {
 			}
 		}
 
+		mergedDesc := h.svc.MergedStoryboardSceneDescriptionForImage(c.Request.Context(), storyboardID, scene.ID, scene.Description)
 		genReq := &service.ImageGenerationRequest{
 			StoryboardID:             storyboardID,
 			SceneID:                  scene.ID,
 			SceneTitle:               scene.Title,
-			SceneDescription:         scene.Description,
+			SceneDescription:         mergedDesc,
 			ReferenceImages:          referenceImages,
 			SceneCharacters:          scene.Characters,
 			CharacterReferenceImages: referenceImages,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the agreed A/B/C changes for storyboard panel and comic-page image generation so scene narrative reliably reaches the image API, Step-2 (scene detail) enrichment is wired in, and long-narrative scenes avoid over-strong image-to-image bias.

## Changes

- **A — Narrative in final prompt**: Gemini JSON fields are capped separately; the combined prompt always leads with a fixed **scene narrative block** (title + description). Final prompt is truncated to **4000 runes** while preserving that block when possible. **Image-to-image** calls append explicit instructions that references are for **identity only**, not paste-on-background.
- **B — Step 2 integration**: New repo method `LatestCompletedSceneGenerationByScene` loads the latest **completed** `StoryboardSceneGeneration` for a plot `scene_id`. `MergedStoryboardSceneDescriptionForImage` merges plot text with `GeneratedDetail`. Used in `GenerateSceneImage`, comic-page generation, HTTP batch `generate/images` and `generate/comic-pages`, and initial `generateSceneImages`.
- **C — Length / mode**: Removed the old **200-rune** cap on the full image prompt for this pipeline. When **narrative length ≥ 120 runes** and the scene is **not** a transition scene, the GenAPI request uses **text-to-image** with **no reference URLs** (transition scenes still use image-to-image when refs exist). The same threshold applies to **Imagen** inline generation in `generateSceneImages` (refs cleared for long narrative).

## Files

- `internal/service/storyboard_image_prompt.go` (+ tests): helpers for merge, narrative block, truncation, ref/operation selection, constraints.
- `internal/service/storyboard_generation.go`, `storyboard_comic_page.go`, `storyboard.go`, HTTP `storyboard_generation.go`, MySQL repo + `domain.Repository` interface.

## Testing

- `go test ./...`
- New unit tests in `storyboard_image_prompt_test.go` for merge, prepend, truncation, and ref/operation selection.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50c97e85-5b7a-42f6-86b9-b8fc929577f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50c97e85-5b7a-42f6-86b9-b8fc929577f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

